### PR TITLE
menucrawler: fix spitting out all menus on first

### DIFF
--- a/menucrawler.py
+++ b/menucrawler.py
@@ -66,7 +66,9 @@ class BackmarktCrawler(MenuCrawler):
         our_day_active = False
         soup = BeautifulSoup(request.text, 'html.parser')
         for h2 in soup.select('div#contentBlock-1 div h2'):
-            if str(day_of_month) in h2.text and str(year) in h2.text:
+            title_without_year = str.join(" ", h2.text.split(" ")[0:-1])
+            if str(day_of_month) in title_without_year \
+                    and str(year) in h2.text:
                 our_day_active = True
             elif our_day_active and str(year) in h2.text:
                 our_day_active = False


### PR DESCRIPTION
The problem on March 1st is that 1 is contained in 2018 and therefore
all date titles got triggered. Therefore, now we split off the year.

Fixes #9.