### PR TITLE
Fix poll and respond in same channel

### DIFF
--- a/hangrybot.py
+++ b/hangrybot.py
@@ -62,7 +62,7 @@ class HangryBot(object):
         text = '"Where do we go?" "Corona" "Backmarkt" "Thai"'
         command = '/poll'
         self.slack_client.api_call(
-            "chat.postMessage",
+            "chat.command",
             channel=channel,
             command=command,
             text=text

--- a/hangrybot.py
+++ b/hangrybot.py
@@ -39,7 +39,7 @@ class HangryBot(object):
             schedule.run_pending()
             time.sleep(self.RTM_READ_DELAY)
 
-    def daily_message(self):
+    def daily_message(self, channel="#lunch"):
         """Print the menus and create a poll."""
         cc = CoronaCrawler()
         text = "*Corona:*\n```"
@@ -47,7 +47,7 @@ class HangryBot(object):
         text += "```"
         self.slack_client.api_call(
             "chat.postMessage",
-            channel="#lunch",
+            channel=channel,
             text=text
         )
         bc = BackmarktCrawler()
@@ -56,14 +56,14 @@ class HangryBot(object):
         text += "```"
         self.slack_client.api_call(
             "chat.postMessage",
-            channel="#lunch",
+            channel=channel,
             text=text
         )
         text = '"Where do we go?" "Corona" "Backmarkt" "Thai"'
         command = '/poll'
         self.slack_client.api_call(
             "chat.postMessage",
-            channel="#lunch",
+            channel=channel,
             command=command,
             text=text
         )
@@ -133,7 +133,7 @@ class HangryBot(object):
                 text=text
             )
         elif "test-daily" in command.lower():
-            self.daily_message()
+            self.daily_message(channel)
         else:
             # Sends the response back to the channel
             self.slack_client.api_call(

--- a/hangrybot.py
+++ b/hangrybot.py
@@ -18,6 +18,7 @@ class HangryBot(object):
 
     def __init__(self):
         self.slack_client = SlackClient(os.environ.get('SLACK_BOT_TOKEN'))
+        self.legacy_token = os.environ.get('SLACK_LEGACY_TOKEN')
         self.starterbot_id = None
 
     def run(self):
@@ -63,6 +64,7 @@ class HangryBot(object):
         command = '/poll'
         self.slack_client.api_call(
             "chat.command",
+            token=self.legacy_token,
             channel=channel,
             command=command,
             text=text


### PR DESCRIPTION
In order for the poll to work, we needed to add a legacy token.

Also, when testing it makes sense that the bot responds in the same channel.